### PR TITLE
Make deb package version match what we use in Citus

### DIFF
--- a/salt/postgres/session_analytics.sls
+++ b/salt/postgres/session_analytics.sls
@@ -1,4 +1,4 @@
-{% set VERSION = '0.0.2' %}
+{% set VERSION = '1.1' %}
 
 make_session_analytics:
   cmd.run:


### PR DESCRIPTION
Our current version in https://github.com/heap/heap/tree/develop/docker/citus/session_analytics is 1.1 (or will be soon), and it's annoying to use a different version number here.