### PR TITLE
[HEAP-7395] Build PostgreSQL 11 extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A `tester` vagrant machine is available as a clean image for testing package ins
 
 Packaging machines currently available:
 * bosun
-* postgres (builds a range of postgres extensions)
+* postgres10 (builds a range of postgres 10 extensions)
+* postgres11 (builds a range of postgres 11 extensions)
 
 `vagrant up` might fail with error on `fpm` gem install. In this case, SSH into the failing box and run `sudo gem install fpm --no-rdoc --no-ri` manually.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,15 @@ Vagrant::configure("2") do |config|
     end
   end
 
+  config.vm.define "postgres11" do |postgres|
+    postgres.vm.hostname = "postgres11"
+    postgres.vm.provision :salt, &provision_salt
+
+    if File.directory?(File.expand_path("../heap"))
+      postgres.vm.synced_folder "../heap/docker/citus/session_analytics", "/home/vagrant/session_analytics"
+    end
+  end
+
   config.vm.define "duo" do |duo|
     duo.vm.hostname = "duo"
     duo.vm.provision :salt, &provision_salt

--- a/salt/postgres11/hll.sls
+++ b/salt/postgres11/hll.sls
@@ -1,0 +1,38 @@
+{% set VERSION = '2.12' %}
+
+download_hll:
+  archive.extracted:
+    - name: /home/vagrant/hll
+    - source: https://github.com/citusdata/postgresql-hll/archive/v{{ VERSION }}.tar.gz
+    - source_hash: md5=bcc2dfef98ceb8d7dcb6657fdd0fb5a9
+    - user: vagrant
+    - archive_format: tar
+
+make_hll:
+  cmd.run:
+    - name: make
+    - cwd: /home/vagrant/hll/postgresql-hll-{{ VERSION }}
+    - creates: /home/vagrant/hll/postgresql-hll-{{ VERSION }}/hll.o
+    - require:
+      - pkg: install_postgres_headers
+      - archive: download_hll
+
+construct_hll_install_dir:
+  file.directory:
+    - name: /tmp/hll
+    - user: vagrant
+
+install_hll:
+  cmd.run:
+    - name: make install DESTDIR=/tmp/hll
+    - cwd: /home/vagrant/hll/postgresql-hll-{{ VERSION }}
+    - creates: /tmp/hll/usr
+
+package_hll:
+  cmd.run:
+    - name: fpm -s dir -t deb -n "postgres11-hll" -v "{{ VERSION }}" -C /tmp/hll usr
+    - creates: /vagrant/postgres11-hll_{{ VERSION }}_amd64.deb
+    - cwd: /vagrant
+    - user: vagrant
+    - require:
+      - gem: fpm

--- a/salt/postgres11/init.sls
+++ b/salt/postgres11/init.sls
@@ -1,0 +1,19 @@
+include:
+  - .hll
+  - .session_analytics
+  - .pgbouncer
+  - .intpair
+
+add_pgdg_repo:
+  pkgrepo.managed:
+    - humanname: Postgres Developer Group
+    - name: deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
+    - key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    - file: /etc/apt/sources.list.d/pgdg.list
+
+install_postgres_headers:
+  pkg.installed:
+    - pkgs:
+      - postgresql-server-dev-11
+    - require:
+      - pkgrepo: add_pgdg_repo

--- a/salt/postgres11/intpair.sls
+++ b/salt/postgres11/intpair.sls
@@ -1,0 +1,38 @@
+{% set VERSION = '0.0.1' %}
+
+download_intpair:
+  archive.extracted:
+    - name: /home/vagrant/pg_intpair
+    - source: https://github.com/heap/pg_intpair/archive/v{{ VERSION }}.tar.gz
+    - source_hash: md5=55acd717e4bdb2f585a11a36ba14a32b
+    - user: vagrant
+    - archive_format: tar
+
+make_intpair:
+  cmd.run:
+    - name: make --always-make USE_PGXS=1
+    - cwd: /home/vagrant/pg_intpair/pg_intpair-{{ VERSION }}
+    - creates: /home/vagrant/pg_intpair/pg_intpair-{{ VERSION }}/intpair.o
+    - require:
+      - pkg: install_postgres_headers
+      - archive: download_intpair
+
+construct_intpair_install_dir:
+  file.directory:
+    - name: /tmp/pg_intpair
+    - user: vagrant
+
+install_intpair:
+  cmd.run:
+    - name: make install USE_PGXS=1 DESTDIR=/tmp/pg_intpair
+    - cwd: /home/vagrant/pg_intpair/pg_intpair-{{ VERSION }}
+    - creates: /tmp/pg_intpair/usr
+
+package_intpair:
+  cmd.run:
+    - name: fpm -s dir -t deb -n "postgres11-intpair" -v "{{ VERSION }}" -C /tmp/pg_intpair usr
+    - creates: /vagrant/postgres11-intpair_{{ VERSION }}_amd64.deb
+    - cwd: /vagrant
+    - user: vagrant
+    - require:
+      - gem: fpm

--- a/salt/postgres11/pgbouncer.sls
+++ b/salt/postgres11/pgbouncer.sls
@@ -1,0 +1,58 @@
+{% set VERSION = '1.7.2-20161209' %}
+{% set GIT_HASH = '61b320ad547cc71219786f9fa82cd548debb13d8' %}
+
+clone_pgbouncer:
+  git.latest:
+    - name: https://github.com/pgbouncer/pgbouncer.git
+    - target: /home/vagrant/pgbouncer
+    - user: vagrant
+    - rev: {{ GIT_HASH }}
+    - submodules: True
+
+install_dependencies:
+  pkg.installed:
+    - pkgs:
+      - libevent-dev
+      - libssl-dev
+      - libc-ares-dev
+      - autoconf
+      - automake
+      - libtool
+      - autoconf-archive
+      - python-docutils
+      - pkg-config
+
+make_pgbouncer:
+  cmd.run:
+    - name: |
+        ./autogen.sh
+        ./configure --prefix=/usr
+        make
+    - cwd: /home/vagrant/pgbouncer
+    - creates: /home/vagrant/pgbouncer/pgbouncer
+
+install_pgbouncer:
+  cmd.run:
+    - name: make install DESTDIR=/tmp/pgbouncer
+    - cwd: /home/vagrant/pgbouncer
+    - creates: /tmp/pgbouncer/usr
+
+# The pgbouncer binary in the official packages is located in `<prefix>/sbin`.
+# We'd like to be consistent with the official packages so we can reuse the same
+# systemd definitions using the path to the binary etc.
+# However, the `make install` step above installs the binary in `${DESTDIR}/<prefix>/bin`
+# instead, so this step manually moves it to the location we want.
+move_to_sbin:
+  file.rename:
+    - name: /tmp/pgbouncer/usr/sbin/pgbouncer
+    - source: /tmp/pgbouncer/usr/bin/pgbouncer
+    - makedirs: True
+
+package_pgbouncer:
+  cmd.run:
+    - name: fpm -s dir -t deb -n "pgbouncer" -d "libc-ares-dev" -v {{ VERSION }} -C /tmp/pgbouncer usr
+    - creates: /vagrant/pgbouncer_{{ VERSION }}_amd64.deb
+    - cwd: /vagrant
+    - user: vagrant
+    - require:
+      - gem: fpm

--- a/salt/postgres11/session_analytics.sls
+++ b/salt/postgres11/session_analytics.sls
@@ -1,0 +1,38 @@
+{% set VERSION = '1.2' %}
+
+make_session_analytics:
+  cmd.run:
+    # Don't trust the built code since we're simply linking through to Heap. Sigh
+    - name: make clean && make
+    - cwd: /home/vagrant/session_analytics
+    - require:
+      - pkg: install_postgres_headers
+      - archive: download_hll
+    - onlyif:
+      - test -d /home/vagrant/session_analytics
+
+construct_session_analytics_install_dir:
+  file.directory:
+    - name: /tmp/session_analytics
+    - user: vagrant
+    - onlyif:
+      - test -d /home/vagrant/session_analytics
+
+install_session_analytics:
+  cmd.run:
+    - name: make install DESTDIR=/tmp/session_analytics
+    - cwd: /home/vagrant/session_analytics
+    - creates: /tmp/session_analytics/usr
+    - onlyif:
+      - test -d /home/vagrant/session_analytics
+
+package_session_analytics:
+  cmd.run:
+    - name: fpm -s dir -t deb -n "postgres11-session-analytics" -v {{ VERSION }} -C /tmp/session_analytics usr
+    - creates: /vagrant/postgres11-session-analytics_{{ VERSION }}_amd64.deb
+    - cwd: /vagrant
+    - user: vagrant
+    - require:
+      - gem: fpm
+    - onlyif:
+      - test -d /home/vagrant/session_analytics

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -7,6 +7,8 @@ base:
     - postgres
   'postgres10':
     - postgres10
+  'postgres11':
+    - postgres11
   'duo':
     - duo_openvpn
   'fluentd':


### PR DESCRIPTION
Changes from PostgreSQL 10 extensions:
- Updated HLL to v2.12 (PG11 support)
- Removed json_build (no longer used)

Based off of #7 